### PR TITLE
NF: Add PsychoPy BIDS plugin to plugins.json

### DIFF
--- a/plugins.json
+++ b/plugins.json
@@ -543,5 +543,22 @@
       "emulator",
       "piloting"
     ]
+  },
+  {
+    "pipname": "psychopy-bids",
+    "name": "PsychoPy BIDS",
+    "author": {
+      "name": "Lukas Wiertz",
+      "email": "lukas.wiertz@uni-graz.at"
+    },
+    "icon": "https://gitlab.com/psygraz/psychopy-bids/-/raw/main/images/orig_BIDS.png",
+    "description": "A PsychoPy plugin to work with the Brain Imaging Data Structure (BIDS) for creating valid BIDS datasets from PsychoPy experiments.",
+    "homepage": "https://psygraz.gitlab.io/psychopy-bids",
+    "docs": "https://psychopy-bids.readthedocs.io",
+    "repo": "https://gitlab.com/psygraz/psychopy-bids",
+    "keywords": [
+      "BIDS",
+      "brain imaging"
+    ]
   }
-] 
+]


### PR DESCRIPTION
This pull request adds a new entry for the psychopy-bids plugin into the plugins.json file. Including this entry is intended to mitigate installation issues currently encountered when using the PsychoPy pip terminal, particularly on macOS systems. By adding the plugin metadata, users will have an alternative installation route and improved discoverability.